### PR TITLE
Problem with calling db method

### DIFF
--- a/lib/Mongoose.pm
+++ b/lib/Mongoose.pm
@@ -78,7 +78,7 @@ sub connect {
     my $self = shift;
     my %p    = @_ || %{ $self->_args };
     my $key  = delete( $p{'-class'} ) || 'default';
-    $self->_connection( MongoDB::Connection->new(@_) )
+    $self->_connection( MongoDB::Connection->new(%p) )
       unless ref $self->_connection;
     $self->_db( { $key => $self->_connection->get_database( $p{db_name} ) } );
     return $self->_db->{$key};


### PR DESCRIPTION
Hi,

There is an issue whereby if the db method is called as specified in the tutorial then the given hostname isn't actually used when the connection is initiated.

The same issue stops the tests running when a MONGOOSEDB environment variable is set at the command line when compiling.

I'm pretty sure this pull request will fix this issue.

Thanks,

Allan
