### PR TITLE
Consuming Mongoose from a role rather than a class

### DIFF
--- a/lib/Mongoose/Document.pm
+++ b/lib/Mongoose/Document.pm
@@ -12,7 +12,30 @@ parameter '-as' => ( isa => 'Str', );
 role {
     my $p          = shift;
     my %args       = @_;
-    my $class_name = $args{consumer}->name;
+    my $class_name;
+    if ($args{consumer}->isa('Moose::Meta::Class'))
+    {
+    	$class_name=$args{consumer}->name;
+    }
+    else
+    {
+    	my $i=1;
+	while ( my @caller = do { package DB; caller( $i++ ) } )
+	{
+		if ($caller[3] eq "MooseX::Role::Parameterized::Meta::Role::Parameterizable::generate_role")
+		{
+			my @args = @DB::args;
+			my %args=@args[1..$#args];
+			if ($args{'consumer'}->isa('Moose::Meta::Class'))
+			{
+				$class_name=$args{'consumer'}->name;
+				last;
+			}
+		}
+	}
+    }
+
+    die("Cannot find a class name to use") unless($class_name);
 
     my $collection_name = $p->{'-collection_name'} || do {
         # sanitize the class name

--- a/t/rolerole.t
+++ b/t/rolerole.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More;
+use lib 't/lib';
+use MongooseT; # this connects to the db for me
+
+{
+	package IntermediateRole;
+	use MooseX::Role::Parameterized;
+	role {
+		my $p          = shift;
+		my %args       = @_;
+		with 'Mongoose::Document';
+	};
+}
+
+{
+	package MyThing;
+	use Moose;
+	with 'IntermediateRole';
+}
+
+package main;
+my $thing=MyThing->new;
+ok( $thing->save, 'Consumed by a role' );
+
+done_testing;


### PR DESCRIPTION
Allow Mongoose::Document to be consumed by an intermediate role
but still save documents etc. based on the original class
which consumed the intermediate role.

Mongoose currently breaks if one does this:

```
{
    package MyRole;
    use MooseX::Role::Parameterized;

    role {
        my $p          = shift;
        my %args       = @_;
        with 'Mongoose::Document';
    };
}

{
    package Thing;
    use Moose;
    with 'MyRole';
    has 'myattrib' => ( is => 'rw', isa =>'Str');
}

package main;

my $thing=new Thing;

$thing->save;
```

this pull request allows the above to work.
