### PR TITLE
auth fails if user does not have access to default db

### DIFF
--- a/lib/Mongoose.pm
+++ b/lib/Mongoose.pm
@@ -127,7 +127,7 @@ sub connect {
     my ( $self, $name ) = @_;
     $name ||= 'default';
     my %p   = %{ $self->_args->{db}{$name} };
-    my $db_name = delete $p{db_name};
+    my $db_name = $p{db_name};
 
     $self->_client->{$name} = $_mongodb_client_class->new(%p)
       unless ref $self->_client->{$name};


### PR DESCRIPTION
If the user does not have access to the default db, and the db_name arg is not supplied to MongoDB::Client->new() remote auth will fail.

Perhaps it is always better to pass db_name?