### PR TITLE
Class::MOP::load_class is deprecated in newer Moose.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ List::Util     					  = 0
 Scalar::Util   					  = 0
 Params::Coerce 					  = 0
 version                           = 0
+Class::Load                       = 0
 
 [MetaResources]
 repository = git://github.com/rodrigolive/mongoose.git

--- a/lib/Mongoose/Document.pm
+++ b/lib/Mongoose/Document.pm
@@ -3,6 +3,7 @@ use strict;
 use Mongoose;
 use MooseX::Role::Parameterized;
 use Mongoose::Meta::AttributeTraits;
+use Class::Load;
 
 parameter '-engine' => ( isa => 'Mongoose::Role::Engine', );
 parameter '-collection_name' => ( isa => 'Str', );
@@ -52,7 +53,7 @@ role {
 
     # load the selected engine
     my $engine = $p->{'-engine'} || 'Mongoose::Engine::Base';
-    Class::MOP::load_class($engine);
+    Class::Load::load_class($engine);
 
     # import the engine role into this class
     with $engine;


### PR DESCRIPTION
Class::Load is the suggested replacement.
