### PR TITLE
Ensure al refs are sorted hashes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,12 @@
+0.28 Sat Apr 18 16:51:40 CEST 2014
+    [ BUGS ]
+    * ensure all DBRef's are sorted hashes to make it work with mongodb v2.6.x (diegok)
+
 0.27 Mon Sep  1 19:25:23 CEST 2014
     [ ENHANCEMENTS ]
     * add optional auth_db_name param for auth against other dbs (gmorten1)
     * testing against remote dbs (gmorten1)
-    
+
 0.26 Sun Aug 24 11:18:25 PDT 2014
     [ CLEANUP ]
     * GH#36 - "package DB" gets $VERSION added by dzil auto-versioning plugin
@@ -13,8 +17,8 @@
 
 0.24 Wed Aug 20 09:12:41 PDT 2014
     [ BUGS ]
-    * GH#35 - Hack to prevent engine from creating self-references 
-    
+    * GH#35 - Hack to prevent engine from creating self-references
+
 0.23 Mon Jan 28 19:28:58 CET 2013
     [ ENHANCEMENTS ]
     * GH#26 - multiple hosts/dbs for different classes (diegok)

--- a/README.pod
+++ b/README.pod
@@ -6,7 +6,7 @@ Mongoose - MongoDB document to Moose object mapper
 
 =head1 VERSION
 
-version 0.27
+version 0.28
 
 =head1 SYNOPSIS
 
@@ -212,7 +212,7 @@ Test cases highly desired and appreciated.
 
 * Finish-up multiple database support
 
-* Allow query->fields to control which fields get expanded into the object. 
+* Allow query->fields to control which fields get expanded into the object.
 
 * Cleanup internals.
 
@@ -228,6 +228,10 @@ L<KiokuDB>
 
     Rodrigo de Oliveira (rodrigolive), C<rodrigolive@gmail.com>
 
+=head1 MAINTAINER
+
+    Diego Kuperman (diegok)
+
 =head1 CONTRIBUTORS
 
     Arthur Wolf
@@ -237,7 +241,6 @@ L<KiokuDB>
     Allan Whiteford (allanwhiteford)
     Kartik Thakore (kthakore)
     David Golden (dagolden)
-    Diego Kuperman (diegok)
 
 =head1 LICENSE
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,8 +1,9 @@
 name    = Mongoose
-version = 0.27
+version = 0.28
 abstract = MongoDB document to Moose object mapper
 license = Perl_5
 author  = Rodrigo de Oliveira <rodrigolive@gmail.com>
+author  = Diego Kuperman <diego@freekeylabs.com>
 copyright_holder = Rodrigo de Oliveira
 
 [@Classic]

--- a/lib/Mongoose.pm
+++ b/lib/Mongoose.pm
@@ -9,7 +9,7 @@ use Moose::Util::TypeConstraints;
 
 # determine if we are on MongoDB 0.503.1
 require version;
-our $_mongodb_client_class = 
+our $_mongodb_client_class =
     version::qv( $MongoDB::VERSION ) >= v0.502.0
         ? 'MongoDB::MongoClient'
         : 'MongoDB::Connection';
@@ -17,8 +17,8 @@ our $_mongodb_client_class =
 class_type $_mongodb_client_class;
 use Carp;
 
-has '_db' => ( 
-    is      => 'rw', 
+has '_db' => (
+    is      => 'rw',
     isa     => 'HashRef',
     default => sub {{}},
 );
@@ -31,10 +31,10 @@ has '_client' => (
     clearer => 'disconnect'
 );
 
-has '_args' => ( 
-    is      => 'rw', 
-    isa     => 'HashRef', 
-    default => sub{{}} 
+has '_args' => (
+    is      => 'rw',
+    isa     => 'HashRef',
+    default => sub{{}}
 );
 
 # naming templates
@@ -373,7 +373,7 @@ Test cases highly desired and appreciated.
 
 * Finish-up multiple database support
 
-* Allow query->fields to control which fields get expanded into the object. 
+* Allow query->fields to control which fields get expanded into the object.
 
 * Cleanup internals.
 
@@ -389,6 +389,10 @@ L<KiokuDB>
 
     Rodrigo de Oliveira (rodrigolive), C<rodrigolive@gmail.com>
 
+=head1 MAINTAINER
+
+    Diego Kuperman (diegok)
+
 =head1 CONTRIBUTORS
 
     Arthur Wolf
@@ -398,7 +402,6 @@ L<KiokuDB>
     Allan Whiteford (allanwhiteford)
     Kartik Thakore (kthakore)
     David Golden (dagolden)
-    Diego Kuperman (diegok)
 
 =head1 LICENSE
 


### PR DESCRIPTION
I've discovered that joins randomly fails on mongodb 2.6.x. This is because it now checks the docs and expect $ref key to come before $id key.

It's easy to reproduce just running the test suit (I've tested it against 2.6.4 and 2.6.9).

On this commit I've replaced all refs hashrefs for Tie::IxHash objects and now all tests pass (including my schema ones).